### PR TITLE
Remove trailing slash from "Read More" URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@ title: Node OS
       <div class="col-sm-12">
           <p class="banner">
             node-os is the first operating system powered by npm
-            <a href="/blog/get-involved/" class="btn btn-large btn-primary">Read More</a>
+            <a href="/blog/get-involved" class="btn btn-large btn-primary">Read More</a>
           </p>
       </div>
     


### PR DESCRIPTION
[node-os.com](node-os.com) "Read More" button onClick action redirects to [http://node-os.com/blog/get-involved/](http://node-os.com/blog/get-involved/) which returns a 404.

As mentioned [here](https://github.com/NodeOS/NodeOS/issues/219) by @aulvi , removing the trailing slash seems to fix it.